### PR TITLE
v1.3.2 fix id_reader require

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "1.3.1"
+    "version": "1.3.2"
 }

--- a/asset/elasticsearch_reader/index.js
+++ b/asset/elasticsearch_reader/index.js
@@ -4,17 +4,19 @@ const moment = require('moment');
 const dateMath = require('datemath-parser');
 const elasticApi = require('@terascope/elasticsearch-api');
 const { getOpConfig, getClient } = require('@terascope/job-components');
+const slicerFn = require('./elasticsearch_date_range/slicer');
+const readerFn = require('./reader');
 const { dateOptions } = require('../utils');
 
 function newSlicer(context, executionContext, retryData, logger) {
     const opConfig = getOpConfig(executionContext.config, 'elasticsearch_reader');
     const client = getClient(context, opConfig, 'elasticsearch');
-    return require('./elasticsearch_date_range/slicer.js')(context, opConfig, executionContext, retryData, logger, client);
+    return slicerFn(context, opConfig, executionContext, retryData, logger, client);
 }
 
 function newReader(context, opConfig) {
     const client = getClient(context, opConfig, 'elasticsearch');
-    return require('./reader.js')(opConfig, client);
+    return readerFn(opConfig, client);
 }
 
 function schema() {

--- a/asset/id_reader/index.js
+++ b/asset/id_reader/index.js
@@ -2,18 +2,20 @@
 
 const _ = require('lodash');
 const { getClient, getOpConfig } = require('@terascope/job-components');
+const readerFn = require('../elasticsearch_reader/reader');
+const slicerFn = require('./id_slicer');
 
 function newSlicer(context, executionContext, retryData, logger) {
     const opConfig = getOpConfig(executionContext.config, 'id_reader');
     const client = getClient(context, opConfig, 'elasticsearch');
 
-    return require('./id_slicer')(context, client, executionContext, opConfig, logger, retryData);
+    return slicerFn(context, client, executionContext, opConfig, logger, retryData);
 }
 
 
 function newReader(context, opConfig) {
     const client = getClient(context, opConfig, 'elasticsearch');
-    return require('../elasticsearch_reader')(opConfig, client);
+    return readerFn(opConfig, client);
 }
 
 function schema() {

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "main": "utils.js",
     "devDependencies": {},
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "description": "bundle of processors for teraslice",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "main": "index.js",
     "scripts": {
         "lint": "eslint asset/**/*.js test/**/*.js",

--- a/scripts/asset-name.js
+++ b/scripts/asset-name.js
@@ -1,6 +1,0 @@
-'use strict';
-
-const asset = require('../asset/asset');
-
-const nodeVersion = process.version.split('.')[0].substr(1);
-console.log(`${asset.name}-v${asset.version}-node-${nodeVersion}-${process.platform}-${process.arch}.zip`);

--- a/test/id_slicer-spec.js
+++ b/test/id_slicer-spec.js
@@ -275,4 +275,23 @@ describe('id_reader', () => {
         const [slice5] = await test.run();
         expect(slice5).toEqual({ count: 100, key: 'events-#ab*' });
     });
+
+    it('newReader returns a function that queries elasticsearch', async () => {
+        const executionConfig = {
+            lifecycle: 'once',
+            operations: [{
+                _op: 'id_reader',
+                type: 'events-',
+                key_type: 'hexadecimal',
+                key_range: ['a', 'b'],
+                index: 'someindex',
+                size: 200
+            }]
+        };
+
+        const type = 'reader';
+
+        const reader = await opTest.init({ executionConfig, type });
+        expect(typeof reader.operation).toEqual('object');
+    });
 });


### PR DESCRIPTION
I made a careless mistake with id_reader in v1.3.1, `return require('../elasticsearch_reader')` should be `return require('../elasticsearch_reader/reader.js')`. 

I added a test to make sure we don't have regressions on this and I elevated the require statements so it will catch more errors faster in the future.