### PR TITLE
v1.5.1 Fix simple api query encoding

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "1.5.0"
+    "version": "1.5.1"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "main": "utils.js",
     "devDependencies": {},
     "scripts": {

--- a/asset/simple_api_reader/index.js
+++ b/asset/simple_api_reader/index.js
@@ -88,6 +88,7 @@ function createClient(context, opConfig) {
                 queryConfig.body.sort.forEach((sortType) => {
                     // We are checking for date sorts, geo sorts are handled by _parseGeoQuery
                     if (sortType[dateFieldName]) {
+                        // there is only one sort allowed
                         // {"date":{"order":"asc"}}
                         sortQuery.sort = `${dateFieldName}:${queryConfig.body.sort[0][dateFieldName].order}`;
                     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "description": "bundle of processors for teraslice",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "main": "index.js",
     "scripts": {
         "lint": "eslint asset/**/*.js test/**/*.js",

--- a/test/simple_api_reader-spec.js
+++ b/test/simple_api_reader-spec.js
@@ -76,6 +76,22 @@ describe('simple_api_reader', () => {
                     count: 5000,
                 }
             }],
+            ['lucene query with url characters', {
+                query: {
+                    token: 'test-token',
+                    q: '(foo:"bar+baz")',
+                    size: 5000,
+                },
+                opConfig: {
+                    query: 'foo:"bar+baz"',
+                    token: 'test-token',
+                    size: 100000,
+                    date_field_name: 'date',
+                },
+                msg: {
+                    count: 5000,
+                }
+            }],
             ['lucene query with fields', {
                 query: {
                     token: 'test-token',


### PR DESCRIPTION
This PR fixes queries to the API server that contain `+` or other URL encoded strings. Previously, `foo:"bar+baz"` was being interpreted as `foo:"bar baz"`, now it should keep the `+`. There should be other url characters this should fix as well.