### PR TITLE
v1.6.1 - Fix es6 scripting and retry on conflict

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "1.6.0"
+    "version": "1.6.1"
 }

--- a/asset/elasticsearch_index_selector/index.js
+++ b/asset/elasticsearch_index_selector/index.js
@@ -76,7 +76,7 @@ function newProcessor(context, opConfig) {
                 indexSpec.update = meta;
 
                 if (opConfig.update_retry_on_conflict > 0) {
-                    meta._retry_on_conflict = opConfig.update_retry_on_conflict;
+                    meta.retry_on_conflict = opConfig.update_retry_on_conflict;
                 }
             } else if (opConfig.delete) {
                 indexSpec.delete = meta;

--- a/asset/elasticsearch_index_selector/index.js
+++ b/asset/elasticsearch_index_selector/index.js
@@ -111,7 +111,7 @@ function newProcessor(context, opConfig) {
 
                     if (opConfig.script) {
                         update.script = {
-                            inline: opConfig.script
+                            source: opConfig.script
                         };
                     }
 

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "main": "utils.js",
     "devDependencies": {},
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "description": "bundle of processors for teraslice",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "scripts": {
         "lint": "eslint --ignore-path .gitignore --ext .js,.ts .",
         "lint:fix": "yarn lint --fix",

--- a/test/index_selector-spec.js
+++ b/test/index_selector-spec.js
@@ -192,13 +192,21 @@ describe('elasticsearch index selector', () => {
             type: 'events',
             id_field: 'name',
             update_fields: ['name'],
+            update_retry_on_conflict: 11,
             delete: false,
             update: true
         };
         const data = [{ some: 'data', name: 'someName' }];
         const results = await opTest.processData(opConfig, data);
 
-        expect(results[0]).toEqual({ update: { _index: 'some_index', _type: 'events', _id: 'someName' } });
+        expect(results[0]).toEqual({
+            update: {
+                _index: 'some_index',
+                _type: 'events',
+                _id: 'someName',
+                retry_on_conflict: 11
+            }
+        });
         expect(results[1]).toEqual({ doc: { name: 'someName' } });
     });
 

--- a/test/index_selector-spec.js
+++ b/test/index_selector-spec.js
@@ -254,6 +254,33 @@ describe('elasticsearch index selector', () => {
         });
     });
 
+    it('script to run as part of an update request', async () => {
+        const opConfig = {
+            _op: 'elasticsearch_index_selector',
+            index: 'hello',
+            type: 'events',
+            upsert: true,
+            update_fields: [],
+            script: 'ctx._source.count += add',
+            script_params: { add: 'add' }
+        };
+        const data = [
+            { count: 1, add: 2 }
+        ];
+        const results = await opTest.processData(opConfig, data);
+
+        expect(results[0]).toEqual({ update: { _index: 'hello', _type: 'events' } });
+        expect(results[1]).toEqual({
+            upsert: { count: 1, add: 2 },
+            script: {
+                source: 'ctx._source.count += add',
+                params: {
+                    add: 2
+                }
+            }
+        });
+    });
+
     it('selfValidation makes sure that the opConfig is configured correctly', () => {
         const errorString = 'elasticsearch_index_selector is mis-configured, if any of the following configurations are set: timeseries, index_prefix or date_field, they must all be used together, please set the missing parameters';
         const baseOP = {


### PR DESCRIPTION
- Use script.source for bulk update scripts instead of script.inline 
- Use retry_on_conflict vs _retry_on_conflict 

Both changes work on elasticsearch>=5.6

Resolves #98 
Resolves #38
