### PR TITLE
Api sender schema  fix

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "2.2.0"
+    "version": "2.2.1"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "private": true,
     "workspaces": {
         "nohoist": [

--- a/asset/src/elasticsearch_sender_api/schema.ts
+++ b/asset/src/elasticsearch_sender_api/schema.ts
@@ -38,8 +38,7 @@ export default class Schema extends ConvictSchema<ElasticsearchSenderConfig> {
 
         const { connectors } = this.context.sysconfig.terafoundation;
 
-        // hack to get around default connection check until schema updates for routed_sender
-        // replaces default connection with routed sender connection
+        // hack to get around default connection check until schema updates and further discussion
         if (connectors.elasticsearch.default == null && getOpConfig(job, 'routed_sender')) {
             this._applyRoutedSenderConnection(job, apiConfigs);
         }
@@ -53,6 +52,9 @@ export default class Schema extends ConvictSchema<ElasticsearchSenderConfig> {
         });
     }
 
+    // replaces default connection with routed sender connection
+    // for ops that use the routed sender, should be removed once routed_sender schema or
+    // implementation is updated
     _applyRoutedSenderConnection(job: ValidatedJobConfig, apiConfigs: APIConfig[]): void {
         job.operations.forEach((op) => {
             if (op._op === 'routed_sender') {

--- a/asset/src/elasticsearch_sender_api/schema.ts
+++ b/asset/src/elasticsearch_sender_api/schema.ts
@@ -39,7 +39,7 @@ export default class Schema extends ConvictSchema<ElasticsearchSenderConfig> {
         const { connectors } = this.context.sysconfig.terafoundation;
 
         // hack to get around default connection check until schema updates for routed_sender
-        // check the first connection on the routed sender op
+        // replaces default connection with routed sender connection
         if (connectors.elasticsearch.default == null && getOpConfig(job, 'routed_sender')) {
             this._applyRoutedSenderConnection(job, apiConfigs);
         }
@@ -56,7 +56,7 @@ export default class Schema extends ConvictSchema<ElasticsearchSenderConfig> {
     _applyRoutedSenderConnection(job: ValidatedJobConfig, apiConfigs: APIConfig[]): void {
         job.operations.forEach((op) => {
             if (op._op === 'routed_sender') {
-                apiConfigs.filter((config) => config._name === op.api_name)
+                apiConfigs.filter((config) => config._name === op.api_name && config.connection === 'default')
                     .forEach((config) => { [config.connection] = Object.values(op.routing); });
             }
         });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "description": "bundle of processors for teraslice",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "private": true,
     "workspaces": [
         "asset"

--- a/test/elasticsearch_sender_api/schema-spec.ts
+++ b/test/elasticsearch_sender_api/schema-spec.ts
@@ -169,6 +169,7 @@ describe('elasticsearch sender api schema for routed sender jobs', () => {
             apis: [
                 {
                     _name: 'elasticsearch_sender_api',
+                    connection: 'default',
                     index: 'test-index',
                 }
             ],

--- a/test/elasticsearch_sender_api/schema-spec.ts
+++ b/test/elasticsearch_sender_api/schema-spec.ts
@@ -1,7 +1,7 @@
 import 'jest-extended';
 import path from 'path';
 import { WorkerTestHarness, newTestJobConfig } from 'teraslice-test-harness';
-import { AnyObject, TestContext, ValidatedJobConfig } from '@terascope/job-components';
+import { AnyObject, TestContext } from '@terascope/job-components';
 import { getESVersion } from 'elasticsearch-store';
 import { TEST_INDEX_PREFIX, makeClient } from '../helpers';
 import { ElasticsearchSenderApi, DEFAULT_API_NAME } from '../../asset/src/elasticsearch_sender_api/interfaces';

--- a/test/fixtures/routed_sender/processor.ts
+++ b/test/fixtures/routed_sender/processor.ts
@@ -1,0 +1,8 @@
+import { BatchProcessor } from '@terascope/job-components';
+import { AnyObject, DataEntity } from '@terascope/utils';
+
+export default class TestSenderApi extends BatchProcessor<AnyObject> {
+    async onBatch(data: DataEntity[]): Promise<DataEntity[]> {
+        return data;
+    }
+}

--- a/test/fixtures/routed_sender/schema.ts
+++ b/test/fixtures/routed_sender/schema.ts
@@ -1,0 +1,8 @@
+import { ConvictSchema } from '@terascope/job-components';
+import { AnyObject } from '@terascope/utils';
+
+export default class Schema extends ConvictSchema<AnyObject> {
+    build(): AnyObject {
+        return {};
+    }
+}


### PR DESCRIPTION
* applies first connection of the routed sender to the api config connection if the api connection is default and there is no default connection available
* bumped version to 2.2.1