### PR TITLE
if no index settings found, return the slice size for windowSize

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "2.6.3"
+    "version": "2.6.4"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "2.6.3",
+    "version": "2.6.4",
     "private": true,
     "workspaces": {
         "nohoist": [
@@ -18,7 +18,7 @@
     "dependencies": {
         "@terascope/data-mate": "^0.29.4",
         "@terascope/elasticsearch-api": "^2.21.4",
-        "@terascope/elasticsearch-asset-apis": "^0.5.3",
+        "@terascope/elasticsearch-asset-apis": "^0.5.4",
         "@terascope/job-components": "^0.52.4",
         "@terascope/teraslice-state-storage": "^0.29.4",
         "@terascope/utils": "^0.40.4",

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-asset-apis",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "description": "Elasticsearch reader and sender apis",
     "publishConfig": {
         "access": "public"

--- a/packages/elasticsearch-asset-apis/src/base-api/index.ts
+++ b/packages/elasticsearch-asset-apis/src/base-api/index.ts
@@ -474,7 +474,7 @@ export class BaseReaderAPI {
             }
         }
 
-        throw new Error(`Could not find settings for index ${index}`);
+        return this.config.size;
     }
 
     get version(): number {


### PR DESCRIPTION
* returns slice size for windowSize instead of throwing an error if cant determine job settings
* bumped asset version to 2.6.4
* bumped elastic-search-asset-apis version to 0.5.4
* bumped assets-apis version in package.json for asset