### PR TITLE
v2.7.1 Only update the slicer metadata update once

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "2.7.0"
+    "version": "2.7.1"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "private": true,
     "workspaces": {
         "nohoist": [
@@ -18,7 +18,7 @@
     "dependencies": {
         "@terascope/data-mate": "^0.30.0",
         "@terascope/elasticsearch-api": "^2.21.4",
-        "@terascope/elasticsearch-asset-apis": "^0.6.0",
+        "@terascope/elasticsearch-asset-apis": "^0.6.1",
         "@terascope/job-components": "^0.52.4",
         "@terascope/teraslice-state-storage": "^0.29.4",
         "@terascope/utils": "^0.40.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "description": "bundle of processors for teraslice",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "private": true,
     "workspaces": [
         "packages/*",

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-asset-apis",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "Elasticsearch reader and sender apis",
     "publishConfig": {
         "access": "public"

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/algorithms/date-helpers.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/algorithms/date-helpers.ts
@@ -422,7 +422,7 @@ export async function determineDateSlicerRange(
                 numOfSlicers
             )[id];
         }
-        const interval = await getInterval(newDates);
+        const interval = await getInterval(newDates, id);
         if (interval == null) return null;
 
         const correctDates = compareRangeToRecoveryData(
@@ -440,7 +440,7 @@ export async function determineDateSlicerRange(
 
     newDates = dateRange[id];
 
-    const interval = await getInterval(newDates);
+    const interval = await getInterval(newDates, id);
     if (interval == null) return null;
 
     // we need to split up times

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/interfaces.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/interfaces.ts
@@ -228,6 +228,17 @@ export type IDSlicerResults = IDReaderSlice | null;
 
 export type ParsedInterval = readonly [step: number, unit: moment.unitOfTime.Base];
 
+export type DateSlicerMetadata = Record<number, {
+    /**
+     * This is interval for the slicer, it will be null if
+     * there is no data for this time period
+    */
+    interval: ParsedInterval|null,
+    start: string;
+    end: string;
+}>;
+export type DateSlicerMetadataHook = (metadata: DateSlicerMetadata) => Promise<void>;
+
 export interface DateSlicerArgs {
     lifecycle: LifeCycle,
     slicerID: number,
@@ -235,11 +246,7 @@ export interface DateSlicerArgs {
     recoveryData?: SlicerRecoveryData[];
     windowState?: WindowState,
     startTime?: Date | string
-    hook?: (args: {
-        interval: ParsedInterval,
-        start: string;
-        end: string;
-    }) => Promise<void>
+    hook?: DateSlicerMetadataHook;
 }
 
 export interface DateSlicerConfig {
@@ -249,18 +256,14 @@ export interface DateSlicerConfig {
     recoveryData?: SlicerRecoveryData[],
     windowState?: WindowState,
     startTime?: Date | string,
-    hook?: (args: {
-        interval: ParsedInterval,
-        start: string;
-        end: string;
-    }) => Promise<void>
+    hook?: DateSlicerMetadataHook;
 }
 
 /**
  * This function is used to determine the interval for each slicer,
 */
 export interface GetIntervalFn {
-    (dates: DateSegments): ParsedInterval|null|Promise<ParsedInterval|null>;
+    (dates: DateSegments, slicerId: number): ParsedInterval|null|Promise<ParsedInterval|null>;
 }
 
 export interface StartPointConfig {

--- a/test/elasticsearch_reader/slicer-spec.ts
+++ b/test/elasticsearch_reader/slicer-spec.ts
@@ -182,9 +182,13 @@ describe('elasticsearch_reader slicer', () => {
             const test = await makeSlicerTest({ opConfig: {} });
             const update = await getMeta(test);
 
-            expect(update.start).toEqual(evenOriginalStart);
-            expect(update.end).toEqual(evenOriginalEnd);
-            expect(update.interval).toEqual([9, 'ms']);
+            expect(update).toEqual({
+                0: {
+                    start: evenOriginalStart,
+                    end: evenOriginalEnd,
+                    interval: [9, 'ms']
+                }
+            });
 
             const [slice] = await test.createSlices();
 
@@ -197,9 +201,13 @@ describe('elasticsearch_reader slicer', () => {
             const test = await makeSlicerTest({ opConfig: { start } });
             const update = await getMeta(test);
 
-            expect(update.start).toEqual(start);
-            expect(update.end).toEqual(evenOriginalEnd);
-            expect(update.interval).toEqual([8, 'ms']);
+            expect(update).toEqual({
+                0: {
+                    start,
+                    end: evenOriginalEnd,
+                    interval: [8, 'ms']
+                }
+            });
 
             const [slice] = await test.createSlices();
 
@@ -212,9 +220,13 @@ describe('elasticsearch_reader slicer', () => {
             const test = await makeSlicerTest({ opConfig: { end } });
             const update = await getMeta(test);
 
-            expect(update.start).toEqual(evenOriginalStart);
-            expect(update.end).toEqual(end);
-            expect(update.interval).toEqual([13, 'ms']);
+            expect(update).toEqual({
+                0: {
+                    start: evenOriginalStart,
+                    end,
+                    interval: [13, 'ms']
+                }
+            });
 
             const [slice] = await test.createSlices();
 

--- a/test/spaces_reader/slicer-spec.ts
+++ b/test/spaces_reader/slicer-spec.ts
@@ -127,7 +127,11 @@ describe('spaces_reader slicer', () => {
         it('will convert auto to proper interval and update the opConfig', async () => {
             harness = await waitForUpdate(opConfig);
             const updatedConfig = await getMeta(harness);
-            expect(updatedConfig.interval).toEqual([60, 's']);
+            expect(updatedConfig).toMatchObject({
+                0: {
+                    interval: [60, 's']
+                }
+            });
         });
     });
 


### PR DESCRIPTION
Only update the slicer metadata once on the job with each of the individual slicer info. This was changed because when many slicers were specified, the concurrent execution updates were triggering elasticsearch version conflicts.