### PR TITLE
elasticsearch bulk api checks for _delete_id in metadata and adds a delete action to the bulk request

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "2.7.5"
+    "version": "2.7.6"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "2.7.5",
+    "version": "2.7.6",
     "private": true,
     "workspaces": {
         "nohoist": [
@@ -18,7 +18,7 @@
     "dependencies": {
         "@terascope/data-mate": "^0.34.6",
         "@terascope/elasticsearch-api": "^2.23.5",
-        "@terascope/elasticsearch-asset-apis": "^0.8.0",
+        "@terascope/elasticsearch-asset-apis": "^0.8.1",
         "@terascope/job-components": "^0.54.5",
         "@terascope/teraslice-state-storage": "^0.31.5",
         "@terascope/utils": "^0.42.1",

--- a/docs/apis/elasticsearch_sender_api.md
+++ b/docs/apis/elasticsearch_sender_api.md
@@ -2,8 +2,7 @@
 
 The `elasticsearch_sender_api` makes the elasticsearch sender functionality available to any processor.   It's a [teraslice api](https://terascope.github.io/teraslice/docs/jobs/configuration#apis) that uses the [api factory](https://terascope.github.io/teraslice/docs/packages/job-components/api/classes/apifactory) to create, cache, and manage multiple elasticsearch senders.   This api is the core of the [elasticsearch bulk](../operations/elasticsearch_bulk.md) operation and utilizes the standard metadata fields, e.g., `_key`, `_process_time`,`_ingest_time`, etc... See the [metadata section](#metadata) for details about metadata fields.
 
-The elasticsearch_sender_api will also look for the metadata field `_delete_key` in each record, if this field exists it adds a delete action to the bulk request.  This adds the ability to do an index and a delete action in the same bulk request which is useful for fixing keying mistakes without having to read through the data twice.
-
+The elasticsearch_sender_api will also look for the metadata field `_delete_id` in each record's metadata, if this field exists it adds a delete operation for the id in the `_delete_id` field to the bulk request.  This allows for an index (or any other action) and a delete operation in the same bulk request.
 
 ## Usage
 ### Example using the elasticsearch sender API

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "description": "bundle of processors for teraslice",
-    "version": "2.7.5",
+    "version": "2.7.6",
     "private": true,
     "workspaces": [
         "packages/*",

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-asset-apis",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "Elasticsearch reader and sender apis",
     "publishConfig": {
         "access": "public"

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-bulk-sender/ElasticsearchBulkSender.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-bulk-sender/ElasticsearchBulkSender.ts
@@ -132,7 +132,7 @@ export class ElasticsearchBulkSender implements RouteSenderAPI {
 
             // allows for creation of new record and deletion of old record in one pass
             // useful for fixing keying mistakes
-            if ((!this.config.update && !this.config.upsert) && record.getMetadata('_delete_key')) {
+            if (record.getMetadata('_delete_key')) {
                 results.push(
                     {
                         delete: {

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-bulk-sender/ElasticsearchBulkSender.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-bulk-sender/ElasticsearchBulkSender.ts
@@ -132,11 +132,11 @@ export class ElasticsearchBulkSender implements RouteSenderAPI {
 
             // allows for creation of new record and deletion of old record in one pass
             // useful for fixing keying mistakes
-            if (record.getMetadata('_delete_key')) {
+            if (record.getMetadata('_delete_id')) {
                 results.push(
                     {
                         delete: {
-                            _id: record.getMetadata('_delete_key'),
+                            _id: record.getMetadata('_delete_id'),
                             _index: this.createRoute(record),
                             _type: this.getType()
                         }

--- a/packages/elasticsearch-asset-apis/test/bulk-send-spec.ts
+++ b/packages/elasticsearch-asset-apis/test/bulk-send-spec.ts
@@ -212,15 +212,15 @@ describe('elasticsearch bulk sender module', () => {
             const data = [
                 DataEntity.make(
                     { action: 'create', field: 'a', _key: 'one' },
-                    { _delete_key: 'bar1', _key: 'one' }
+                    { _delete_id: 'bar1', _key: 'one' }
                 ),
                 DataEntity.make(
                     { action: 'create', field: 'b', _key: 'two' },
-                    { _delete_key: 'bar2', _key: 'two' }
+                    { _delete_id: 'bar2', _key: 'two' }
                 ),
                 DataEntity.make(
                     { action: 'create', field: 'c', _key: 'three' },
-                    { _delete_key: 'bar3', _key: 'three' }
+                    { _delete_id: 'bar3', _key: 'three' }
                 )
             ];
 

--- a/packages/elasticsearch-asset-apis/test/bulk-send-spec.ts
+++ b/packages/elasticsearch-asset-apis/test/bulk-send-spec.ts
@@ -255,33 +255,6 @@ describe('elasticsearch bulk sender module', () => {
             });
         });
 
-        it('will not format update with delete data even if _delete_key in metadata', async () => {
-            const sender = createSender({ update: true });
-            const data = [
-                DataEntity.make(
-                    { action: 'update' },
-                    { _delete_key: 'bar' }
-                )
-            ];
-
-            const [
-                meta,
-                doc,
-                deleteBulk
-            ] = sender.formatBulkData(data);
-
-            expect(meta).toEqual({
-                update: {
-                    _index: 'es_assets__sender_api_',
-                    _type: type,
-                }
-            });
-
-            expect(doc).toEqual({ doc: data[0] });
-
-            expect(deleteBulk).toBeUndefined();
-        });
-
         it('can upsert specified fields by passing in an array of keys matching the document', async () => {
             const opConfig = {
                 index: 'some_index',


### PR DESCRIPTION
* formatBulkData checkes for _delete_id in metadata and adds  a delete operation for that key in the bulk request
* updated tests
* added explanation to docs and edited docs
* bumped version to elasticsearch asset to v2.7.6 and elasticsearch-assets-api to v0.8.1
* updated the elasticsearch-assets-api version to 0.8.1 in the elasticsearch assets package.json