### PR TITLE
replaced random.uuid with datatype.uuid in data-schema

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "2.7.10"
+    "version": "2.7.11"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "2.7.10",
+    "version": "2.7.11",
     "private": true,
     "workspaces": {
         "nohoist": [

--- a/asset/src/elasticsearch_data_generator/data-schema.ts
+++ b/asset/src/elasticsearch_data_generator/data-schema.ts
@@ -56,7 +56,7 @@ const nativeSchema = {
         faker: 'internet.url'
     },
     uuid: {
-        faker: 'random.uuid'
+        faker: 'datatype.uuid'
     },
     created: {
         function: dateNow

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "description": "bundle of processors for teraslice",
-    "version": "2.7.10",
+    "version": "2.7.11",
     "private": true,
     "workspaces": [
         "packages/*",


### PR DESCRIPTION
- Replaced `random.uuid` with `datatype.uuid` in `data-schema.ts` due to the following warning:
```
Deprecation Warning: faker.random.uuid is now located in faker.datatype.uuid
````
  