### PR TITLE
rework fetch to stop using max window size

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "3.0.0"
+    "version": "3.1.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,6 +1,6 @@
 {
     "name": "asset",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "private": true,
     "workspaces": {
         "nohoist": [
@@ -18,7 +18,7 @@
     "dependencies": {
         "@terascope/data-mate": "^0.38.1",
         "@terascope/elasticsearch-api": "^3.2.0",
-        "@terascope/elasticsearch-asset-apis": "^0.9.1",
+        "@terascope/elasticsearch-asset-apis": "^0.10.0",
         "@terascope/job-components": "^0.57.0",
         "@terascope/teraslice-state-storage": "^0.35.0",
         "@terascope/utils": "^0.44.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "description": "bundle of processors for teraslice",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "private": true,
     "workspaces": [
         "packages/*",
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@terascope/data-types": "^0.35.1",
         "@terascope/elasticsearch-api": "^3.2.0",
-        "@terascope/elasticsearch-asset-apis": "^0.9.1",
+        "@terascope/elasticsearch-asset-apis": "^0.10.0",
         "@terascope/eslint-config": "^0.7.1",
         "@terascope/job-components": "^0.57.0",
         "@terascope/scripts": "^0.49.0",

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@terascope/elasticsearch-asset-apis",
-    "version": "0.9.1",
+    "version": "0.10.0",
     "description": "Elasticsearch reader and sender apis",
     "publishConfig": {
         "access": "public"

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/ElasticsearchReaderAPI.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/ElasticsearchReaderAPI.ts
@@ -183,8 +183,10 @@ export class ElasticsearchReaderAPI {
                 backoff: 1.1,
                 delay: 250,
                 retries: retryLimit,
-                matches: ['result set contained exactly'],
-                reason: `Retry limit (${retryLimit}) hit`
+                matches: ['result set contained exactly']
+                // reason disable due to this bug:
+                // https://github.com/terascope/teraslice/issues/3286
+                // reason: `Retry limit (${retryLimit}) hit`
             }
         );
         return result;

--- a/test/elasticsearch_reader/fetcher-spec.ts
+++ b/test/elasticsearch_reader/fetcher-spec.ts
@@ -97,18 +97,19 @@ describe('elasticsearch_reader fetcher', () => {
 
     it('fetcher can return formatted data', async () => {
         // this range has 48 records
+        const sliceSize = 48;
         const slice = {
             start: '2019-04-26T15:00:23.201Z',
             end: '2019-04-26T15:00:23.220Z',
             limit: '2019-04-26T15:00:23.394Z',
-            count: 10000
+            count: sliceSize
         };
 
         const test = await makeFetcherTest({ size: 100 });
         const results = await test.runSlice(slice);
 
         expect(Array.isArray(results)).toEqual(true);
-        expect(results).toBeArrayOfSize(48);
+        expect(results).toBeArrayOfSize(sliceSize);
         const doc = results[0];
         expect(DataEntity.isDataEntity(doc)).toEqual(true);
 

--- a/test/elasticsearch_reader/fetcher-spec.ts
+++ b/test/elasticsearch_reader/fetcher-spec.ts
@@ -207,7 +207,11 @@ describe('elasticsearch_reader fetcher', () => {
             };
 
             const test = await makeFetcherTest({ size: 100 });
-            const errMsg = 'Retry limit (5) hit, caused by Error: The result set contained exactly 32 records, searching again with size: 48';
+            // Ideally we'd be testing for the following error message, but
+            // there is a bug in pRetry. See _fetch in the
+            // `ElasticsearchReaderAPI` for details
+            // const errMsg = 'Retry limit (5) hit, caused by Error: The result set contained exactly 32 records, searching again with size: 48';
+            const errMsg = 'The result set contained exactly 32 records, searching again with size: 48';
             try {
                 await test.runSlice(slice);
                 throw new Error('should have error');

--- a/test/elasticsearch_reader/fetcher-spec.ts
+++ b/test/elasticsearch_reader/fetcher-spec.ts
@@ -210,7 +210,8 @@ describe('elasticsearch_reader fetcher', () => {
             // Ideally we'd be testing for the following error message, but
             // there is a bug in pRetry. See _fetch in the
             // `ElasticsearchReaderAPI` for details
-            // const errMsg = 'Retry limit (5) hit, caused by Error: The result set contained exactly 32 records, searching again with size: 48';
+            // const errMsg = 'Retry limit (5) hit, caused by Error: The result
+            // set contained exactly 32 records, searching again with size: 48';
             const errMsg = 'The result set contained exactly 32 records, searching again with size: 48';
             try {
                 await test.runSlice(slice);

--- a/test/fixtures/data/even-spread-extra1.ts
+++ b/test/fixtures/data/even-spread-extra1.ts
@@ -1,0 +1,71 @@
+import { TypeConfigFields } from '@terascope/data-types';
+import { cloneDeep } from '@terascope/utils';
+
+// These records are meant to fall within the following range
+// start: '2019-04-26T15:00:23.201Z',
+// end: '2019-04-26T15:00:23.207Z',
+// changes:
+// uuid: `deadbeef` suffix
+// ip: ends in 18
+// ipv6: ends in :1818
+// url: 18 appended to end of domain name
+// created: randomly selected milliseconds that fall within range
+const data = [
+    {
+        ip: '72.8.102.18',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_3)  AppleWebKit/536.1.0 (KHTML, like Gecko) Chrome/17.0.855.0 Safari/536.1.0',
+        url: 'https://billie18.biz',
+        uuid: '5d085b16-ef14-4f23-b118-d8c4deadbeef',
+        created: '2019-04-26T15:00:23.202+00:00',
+        ipv6: 'a3fc:ae59:d97f:c8fa:c5a6:8210:925d:1818',
+        location: '-72.7229, -178.84325',
+        bytes: 887820
+    },
+    {
+        ip: '179.104.247.18',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_5_2 rv:2.0; CO) AppleWebKit/536.2.1 (KHTML, like Gecko) Version/6.0.6 Safari/536.2.1',
+        url: 'http://makayla18.net',
+        uuid: '39d471cf-f478-4324-91bf-ef5bdeadbeef',
+        created: '2019-04-26T15:00:23.206+00:00',
+        ipv6: '3eae:b483:7dff:317d:f28c:1002:f213:1818',
+        location: '-24.41098, 105.53778',
+        bytes: 2129260
+    },
+    {
+        ip: '123.137.14.18',
+        userAgent: 'Mozilla/5.0 (Windows; U; Windows NT 5.0) AppleWebKit/534.2.2 (KHTML, like Gecko) Chrome/25.0.883.0 Safari/534.2.2',
+        url: 'https://marisa18.name',
+        uuid: 'dcdd9999-761c-44e7-a312-91bbdeadbeef',
+        created: '2019-04-26T15:00:23.204+00:00',
+        ipv6: '7f70:9cb7:be35:f55a:4b3e:0f98:383e:1818',
+        location: '87.16682, -125.64349',
+        bytes: 5233485
+    },
+    {
+        ip: '240.44.7.18',
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_9 rv:2.0; SK) AppleWebKit/536.1.0 (KHTML, like Gecko) Version/6.1.6 Safari/536.1.0',
+        url: 'https://darron18.net',
+        uuid: '02033bfc-7de8-4c78-a2ce-6b4ddeadbeef',
+        created: '2019-04-26T15:00:23.202+00:00',
+        ipv6: 'ab88:805e:55db:0750:b143:61ce:e07a:1818',
+        location: '89.30019, -158.5777',
+        bytes: 802825
+    }
+];
+
+const types: TypeConfigFields = {
+    ip: { type: 'IP' },
+    userAgent: { type: 'Keyword' },
+    url: { type: 'Keyword' },
+    uuid: { type: 'Keyword' },
+    created: { type: 'Date' },
+    ipv6: { type: 'Keyword' },
+    location: { type: 'GeoPoint' },
+    bytes: { type: 'Integer' }
+};
+
+export = {
+    data: cloneDeep(data),
+    types,
+    index: 'even_spread'
+}

--- a/test/spaces_reader/fetcher-spec.ts
+++ b/test/spaces_reader/fetcher-spec.ts
@@ -42,7 +42,7 @@ describe('spaces_reader fetcher', () => {
             ['range query', {
                 query: {
                     q: 'date:[2017-09-23T18:07:14.332Z TO 2017-09-25T18:07:14.332Z}',
-                    size: 100
+                    size: 150
                 },
                 opConfig: {
                     token,
@@ -60,7 +60,7 @@ describe('spaces_reader fetcher', () => {
             ['lucene query', {
                 query: {
                     q: '(foo:bar)',
-                    size: 5000,
+                    size: 7500,
                 },
                 opConfig: {
                     query: 'foo:bar',
@@ -75,7 +75,7 @@ describe('spaces_reader fetcher', () => {
             ['lucene query with url characters', {
                 query: {
                     q: '(foo:"bar+baz")',
-                    size: 5000,
+                    size: 7500,
                 },
                 opConfig: {
                     query: 'foo:"bar+baz"',
@@ -90,7 +90,7 @@ describe('spaces_reader fetcher', () => {
             ['lucene query with fields', {
                 query: {
                     q: '(test:query OR other:thing AND bytes:>=2000)',
-                    size: 100,
+                    size: 150,
                     fields: 'foo,bar,date'
                 },
                 opConfig: {
@@ -107,7 +107,7 @@ describe('spaces_reader fetcher', () => {
             ['lucene query with date range', {
                 query: {
                     q: 'example_date:[2017-09-23T18:07:14.332Z TO 2017-09-25T18:07:14.332Z} AND (foo:bar)',
-                    size: 200,
+                    size: 300,
                 },
                 opConfig: {
                     query: 'foo:bar',
@@ -124,7 +124,7 @@ describe('spaces_reader fetcher', () => {
             ['lucene query with geo point query', {
                 query: {
                     q: '(foo:bar)',
-                    size: 100,
+                    size: 150,
                     geo_point: '52.3456,79.6784',
                     geo_distance: '200km'
                 },
@@ -144,7 +144,7 @@ describe('spaces_reader fetcher', () => {
             ['lucene query with geo bounding box query', {
                 query: {
                     q: '(foo:bar)',
-                    size: 100000,
+                    size: 1500,
                     geo_box_top_left: '34.5234,79.42345',
                     geo_box_bottom_right: '54.5234,80.3456',
                     geo_sort_point: '52.3456,79.6784'
@@ -159,7 +159,9 @@ describe('spaces_reader fetcher', () => {
                     geo_box_bottom_right: '54.5234,80.3456',
                     geo_sort_point: '52.3456,79.6784',
                 },
-                msg: {}
+                msg: {
+                    count: 1000
+                }
             }],
 
         ])('when performing a %s', (m, { query, opConfig: _opConfig, msg }) => {
@@ -183,9 +185,6 @@ describe('spaces_reader fetcher', () => {
                 ]
             }), { clients });
 
-            // query size are overridden for unbounded fetches
-            query.size = maxSize;
-
             let results: DataEntity[];
 
             beforeEach(async () => {
@@ -205,6 +204,7 @@ describe('spaces_reader fetcher', () => {
                     });
 
                 await harness.initialize();
+                // FIXME: is msg ... a slice?
                 results = await harness.runSlice(msg);
             });
 
@@ -257,7 +257,7 @@ describe('spaces_reader fetcher', () => {
 
                 scope.post(`/${testIndex}?token=${token}`, {
                     q: '(test:query)',
-                    size: 100000,
+                    size: 7500,
                 })
                     .delay(500)
                     .reply(200, {


### PR DESCRIPTION
fetch now uses an expanded slice count as the query size

refs: #948