### PR TITLE
optionally setting fetch size to max_result_window

### DIFF
--- a/asset/src/elasticsearch_reader_api/schema.ts
+++ b/asset/src/elasticsearch_reader_api/schema.ts
@@ -19,6 +19,11 @@ export const schema = {
             isValidIndex(val);
         }
     },
+    errorOnSizeTooBig: {
+        doc: 'changes behavior of slice size expansion during fetch, setting this to false will make failing queries succeed but could result in missed data',
+        default: true,
+        format: Boolean
+    },
     field: {
         doc: 'DEPRECATED: USE "id_field_name" INSTEAD. field to use for id_slicer if subslice_by_key is set to true',
         default: null,

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/ElasticsearchReaderAPI.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/ElasticsearchReaderAPI.ts
@@ -136,7 +136,13 @@ export class ElasticsearchReaderAPI {
             const expandedSize = Math.ceil(queryParams.count * countExpansionFactor);
             if (this.windowSize) {
                 if (expandedSize >= this.windowSize) {
-                    throw new Error(`The query size, ${expandedSize}, is greater than the index.max_result_window: ${this.windowSize}`);
+                    const msg = `The query size, ${expandedSize}, is greater than the index.max_result_window: ${this.windowSize}`;
+                    if (this.config.errorOnSizeTooBig) {
+                        throw new Error(msg);
+                    } else {
+                        this.logger.warn(`${msg}, setting querySize to index.max_result_window`);
+                        querySize = this.windowSize;
+                    }
                 } else {
                     querySize = expandedSize;
                 }
@@ -163,9 +169,15 @@ export class ElasticsearchReaderAPI {
                 // throw away these results, expand querySize and query again
                 // by relying on pRetry
                 const expandedSize = Math.ceil(querySize * countExpansionFactor);
-                if (this.windowSize) {
+                if (this.windowSize && queryParams.count) {
                     if (expandedSize >= this.windowSize) {
-                        throw new Error(`The query size, ${expandedSize}, is greater than the index.max_result_window: ${this.windowSize}`);
+                        const msg = `The query size, ${expandedSize}, is greater than the index.max_result_window: ${this.windowSize}`;
+                        if (this.config.errorOnSizeTooBig) {
+                            throw new Error(msg);
+                        } else {
+                            this.logger.warn(`${msg}, setting querySize to index.max_result_window`);
+                            querySize = this.windowSize;
+                        }
                     } else {
                         querySize = expandedSize;
                     }

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/index.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/index.ts
@@ -52,6 +52,6 @@ export async function createSpacesReaderAPI({
     if (config.response_type === FetchResponseType.data_frame && !config.type_config) {
         config.type_config = await client.getDataType();
     }
-
+    config.errorOnSizeTooBig = false;
     return new ElasticsearchReaderAPI(config, client, emitter, logger);
 }

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/interfaces.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/interfaces.ts
@@ -330,6 +330,7 @@ export enum FetchResponseType {
 }
 
 export interface ESReaderOptions {
+    errorOnSizeTooBig: boolean;
     index: string;
     id_field_name?: string;
     size: number;


### PR DESCRIPTION
This is WIP, meant for discussion with Kimbro.

I think setting this to max_result_window makes sense.

I think the problem we have internally is that the spaces queries to the API server has max of 200k, whereas the api servers have a max of 2m.  So this won't trigger in the case of the api server doing its backend query to ES.

refs: https://github.com/terascope/elasticsearch-assets/issues/948