### PR TITLE
increase dependabot pull to 6 and remove assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
       timezone: US/Arizona
     open-pull-requests-limit: 3
     assignees:
-      - godber
-      - jsnoble
       - sotojn
       - busma13
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: weekly
       time: '04:00'
       timezone: US/Arizona
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 6
     assignees:
       - sotojn
       - busma13


### PR DESCRIPTION
I have added the following changes to the `dependabot.yaml` file:

- Removed two accounts from the assignees list 
- Increased the pull request limit for dependabot from 3 to 6