### PR TITLE
update node 16 and 18 versions in test-asset.yml

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@42e888b5058dd6d66d93707331ccf9a1e9315734
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@2b69deef97171811097c074fe1e11da4edf7d7b0
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [14.21.3, 16.19.1, 18.16.0]
+        node-version: [14.21.3, 16.20.2, 18.18.2]
     steps:
       - uses: actions/checkout@v3
 
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [14.21.3, 16.19.1, 18.16.0]
+        node-version: [14.21.3, 16.20.2, 18.18.2]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
   #       uses: actions/setup-node@v3
   #       with:
   #         # NOTE: Hard Coded Node Version
-  #         node-version: '18.16.0'
+  #         node-version: '18.18.2'
   #     - run: yarn setup
   #     - run: yarn lint
   #     # TODO: Ideally we'd be able to at least run unit tests that don't require docker.


### PR DESCRIPTION
I have updated node versions inside the test-asset.yml file. The new node versions are listed below:
- `node 18.18.2`
- `node 16.20.2`

I have also updated the URL inside the `build-and-publish-asset.yml` to use the updated workflow.

Reference to issue in the Teraslice repo [here](https://github.com/terascope/teraslice/issues/3459)