### PR TITLE
Bump Typscript 5.2.2

### DIFF
--- a/asset/src/elasticsearch_data_generator/data-schema.ts
+++ b/asset/src/elasticsearch_data_generator/data-schema.ts
@@ -91,7 +91,7 @@ function getFormatFunction(format: DateOptions, options: FormatOptions = {}) {
 export default function getSchema(opConfig: DataGenerator, otherSchema: AnyObject): AnyObject {
     const startDate = opConfig.start ? moment(opConfig.start) : moment(0); // 01 January, 1970 UTC
     const endDate = opConfig.end ? moment(opConfig.end) : moment();
-    const schema = isEmpty(otherSchema) ? nativeSchema : otherSchema;
+    const schema: AnyObject = isEmpty(otherSchema) ? nativeSchema : otherSchema;
     const start = startDate.valueOf();
     const end = endDate.valueOf();
     const diff = end - start;

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "node-notifier": "^10.0.1",
         "teraslice-test-harness": "^0.29.0",
         "ts-jest": "^29.1.2",
-        "typescript": "^4.9.5"
+        "typescript": "~5.2.2"
     },
     "engines": {
         "node": ">=16.19.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,
+        "ignoreDeprecations": "5.0",
         "disableReferencedProjectLoad": true,
         "typeRoots": [
             "./node_modules/@types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6340,10 +6340,10 @@ typedoc@~0.25.4:
     minimatch "^9.0.3"
     shiki "^0.14.7"
 
-typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@~5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 uglify-js@^3.1.4:
   version "3.17.3"


### PR DESCRIPTION
The following updates have been made:

- Bumped Typescript from `4.9.5` to `5.2.2`
- Added `AnyObject` type to schema in `getSchema()` method
  - This is compliant with the new Typescript 5 rules