### PR TITLE
Update node version

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@87417c24b289012e5665f4aea5eaad78431dbe31
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@6dfb22a4299550935fb58a16aa544837a43fe38c
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [16.20.2, 18.18.2]
+        node-version: [18.19.1]
     steps:
       - uses: actions/checkout@v3
 
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [16.20.2, 18.18.2]
+        node-version: [18.19.1]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - uses: actions/checkout@v3

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "3.5.5"
+    "version": "3.5.6"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -30,7 +30,7 @@
     },
     "devDependencies": {},
     "engines": {
-        "node": ">=16.19.0",
+        "node": ">=18.0.0",
         "yarn": ">=1.22.19"
     },
     "terascope": {}

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "asset",
     "displayName": "Asset",
-    "version": "3.5.5",
+    "version": "3.5.6",
     "private": true,
     "description": "",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Elasticsearch Assets",
-    "version": "3.5.5",
+    "version": "3.5.6",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "typescript": "~5.2.2"
     },
     "engines": {
-        "node": ">=16.19.0",
+        "node": ">=18.0.0",
         "yarn": ">=1.22.19"
     },
     "terascope": {

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -39,7 +39,7 @@
         "elasticsearch": "^15.4.1"
     },
     "engines": {
-        "node": ">=16.19.0",
+        "node": ">=18.0.0",
         "yarn": ">=1.22.19"
     },
     "publishConfig": {

--- a/packages/terafoundation_elasticsearch_connector/package.json
+++ b/packages/terafoundation_elasticsearch_connector/package.json
@@ -29,7 +29,7 @@
         "@types/elasticsearch": "^5.0.40"
     },
     "engines": {
-        "node": ">=16.19.0",
+        "node": ">=18.0.0",
         "yarn": ">=1.22.19"
     },
     "publishConfig": {


### PR DESCRIPTION
Update minimum node engine version from 16.19.0 to 18.0.0.
Drop node 16 from test matrix
Add new `workflows` hash to `build-and-publish-asset.yml`