### PR TITLE
Remove environment variable that disables TLS verification 

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "3.5.7"
+    "version": "3.5.8"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "asset",
     "displayName": "Asset",
-    "version": "3.5.7",
+    "version": "3.5.8",
     "private": true,
     "description": "",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Elasticsearch Assets",
-    "version": "3.5.7",
+    "version": "3.5.8",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-asset-apis",
     "displayName": "Elasticsearch Asset Apis",
-    "version": "0.11.10",
+    "version": "0.11.11",
     "description": "Elasticsearch reader and sender apis",
     "homepage": "https://github.com/terascope/elasticsearch-assets",
     "repository": "git@github.com:terascope/elasticsearch-assets.git",

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/SpacesReaderClient.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/SpacesReaderClient.ts
@@ -12,9 +12,6 @@ import {
 } from './interfaces';
 import { throwRequestError } from './throwRequestError';
 
-// eslint-disable-next-line
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 export class SpacesReaderClient implements ReaderClient {
     // NOTE: currently we are not supporting id based reader queries
     // NOTE: currently we do no have access to _type or _id of each doc


### PR DESCRIPTION
This PR makes the following changes:

- Removes `NODE_TLS_REJECT_UNAUTHORIZED` environment variable at the top level of the `SpacesReaderClient`
  - This was globally disabling the verification of ca certs with any node process that imported this asset
- Bumped  **@terascope/elasticsearch-asset-apis** from `v0.11.10` to `v0.11.11`