### PR TITLE
Add node 22 workflows

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@f6b34eb9b2ea5d113078381237ca81e5520e6f5b
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@73a80a9e19cde53baf8a918e2c7c69bf39ca884a
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -72,6 +72,10 @@ jobs:
       - name: Test apis for ${{ matrix.search-version }}
         run: yarn --silent test:${{ matrix.search-version }}
         working-directory: ./packages/elasticsearch-asset-apis
+      - run: yarn global add teraslice-cli
+      - run: teraslice-cli -v
+      - run: teraslice-cli assets build
+      - run: ls -l build/
 
 
 # TODO:

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.2.0]
     steps:
       - uses: actions/checkout@v3
 
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [18.19.1, 20.11.1]
+        node-version: [18.19.1, 20.11.1, 22.2.0]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - uses: actions/checkout@v3

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "3.6.0"
+    "version": "3.7.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "asset",
     "displayName": "Asset",
-    "version": "3.6.0",
+    "version": "3.7.0",
     "private": true,
     "description": "",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Elasticsearch Assets",
-    "version": "3.6.0",
+    "version": "3.7.0",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",


### PR DESCRIPTION
This PR makes the following changes:

- Updates github actions workflow that includes node `v22.2.0` 
- Bumps **elasticsearch-assets** to `v3.7.0`
- Adds asset zip testing to CI to ensure asset zips properly before merge