### PR TITLE
Backwards compatibility fix for teraslice 

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "3.7.0"
+    "version": "3.7.1"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -20,7 +20,7 @@
         "@terascope/data-mate": "^0.56.2",
         "@terascope/elasticsearch-api": "^3.20.2",
         "@terascope/elasticsearch-asset-apis": "^0.12.0",
-        "@terascope/job-components": "^0.74.2",
+        "@terascope/job-components": "^0.75.0",
         "@terascope/teraslice-state-storage": "^0.53.2",
         "@terascope/utils": "^0.59.1",
         "datemath-parser": "^1.0.6",

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "asset",
     "displayName": "Asset",
-    "version": "3.7.0",
+    "version": "3.7.1",
     "private": true,
     "description": "",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "@terascope/elasticsearch-api": "^3.20.2",
         "@terascope/elasticsearch-asset-apis": "^0.12.0",
         "@terascope/eslint-config": "^0.8.0",
-        "@terascope/job-components": "^0.74.2",
+        "@terascope/job-components": "^0.75.0",
         "@terascope/scripts": "0.77.2",
         "@terascope/teraslice-state-storage": "^0.53.2",
         "@terascope/types": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Elasticsearch Assets",
-    "version": "3.7.0",
+    "version": "3.7.1",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,12 +803,12 @@
     progress "^2.0.3"
     yargs "^17.2.1"
 
-"@terascope/job-components@^0.74.2":
-  version "0.74.2"
-  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.74.2.tgz#de875f792644abf3324f74d98e6b7daa046d7fff"
-  integrity sha512-FEliIWkcK43Q+kiONkwutXgV/f9qQMGUjesmJq9IyqYswOd7ZHtlXCjBUziKqdUWZ01OZ3YDzFxeuufJoLflUg==
+"@terascope/job-components@^0.75.0":
+  version "0.75.0"
+  resolved "https://registry.yarnpkg.com/@terascope/job-components/-/job-components-0.75.0.tgz#03739729d7d7aee722b6291418987084cf65aaa9"
+  integrity sha512-QbIAKfbjX5Wj8A/hZvjE0E8y9hvW9QecQIw6eMwTRneudx2OPQcissCCYNlxBpfP13dK/U85BIqOVFZRTh8KcA==
   dependencies:
-    "@terascope/utils" "^0.59.1"
+    "@terascope/utils" "^0.59.2"
     convict "^6.2.4"
     convict-format-with-moment "^6.2.0"
     convict-format-with-validator "^6.2.0"


### PR DESCRIPTION
This PR makes the following changes:

- Introduces backwards compatibility for teraslice versions before `v1.4.0`
  - This fixes an issue where using a teraslice version older than version `v1.4.0` would throw `TypeError: this.promMetrics.addGauge is not a function`
- Bump **elasticsearch-assets** to `v3.7.1`
- Updates the following dependencies:
  - **@terascope/job-components** from `v0.74.2` to `v0.75.0`

ref: https://github.com/terascope/teraslice/issues/3625