### PR TITLE
pass CA cert to spacesReaderClient from spaces_reader_api

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "3.7.1"
+    "version": "3.7.2"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "asset",
     "displayName": "Asset",
-    "version": "3.7.1",
+    "version": "3.7.2",
     "private": true,
     "description": "",
     "license": "MIT",
@@ -19,7 +19,7 @@
     "dependencies": {
         "@terascope/data-mate": "^0.56.2",
         "@terascope/elasticsearch-api": "^3.20.2",
-        "@terascope/elasticsearch-asset-apis": "^0.12.0",
+        "@terascope/elasticsearch-asset-apis": "^0.12.1",
         "@terascope/job-components": "^0.75.1",
         "@terascope/teraslice-state-storage": "^0.53.2",
         "@terascope/utils": "^0.59.1",

--- a/asset/src/spaces_reader_api/schema.ts
+++ b/asset/src/spaces_reader_api/schema.ts
@@ -38,7 +38,12 @@ const apiSchema = {
         doc: 'The number of times that the spaces client will try to retry a request',
         default: 3,
         format: Number
-    }
+    },
+    caCertificate: {
+        doc: 'CA certificate used to validate https endpoint',
+        default: undefined,
+        format: String
+    },
 };
 
 const spacesSchema = Object.assign({}, clone, apiSchema) as AnyObject;

--- a/docs/apis/spaces_reader_api.md
+++ b/docs/apis/spaces_reader_api.md
@@ -244,6 +244,8 @@ api.version === 6
 | geo_sort_order         | the order used for sorting geo queries, can either be 'asc' or 'desc'                                                                                                                | String                                        | optional, defaults to 'asc'                                                                                                                                                |
 | geo_sort_unit          | the unit of measurement for sorting, may be set to 'mi', 'km', 'm','yd', 'ft                                                                                                         | String                                        | optional, defaults to 'm'                                                                                                                                                  |
 | variables              | can specify an xLuceneVariable object for the given xLucene query                                                                                                                    | Object                                        | optional                                                                                                                                                                   |
+| caCertificate          | CA certificate used to validate an https endpoint | String | optional |
+
 
 `NOTE`: a difference in behavior compared to the elasticsearch_reader is that the default geo distance sort will be ignored if any sort parameter is specified on the query. Sorting on geo distance while specifying another sorting parameter is still possible if you set any other geo sorting parameter, which will cause the query to sort by both.
 

--- a/docs/operations/spaces_reader.md
+++ b/docs/operations/spaces_reader.md
@@ -89,6 +89,7 @@ const expected fetchResults = [
 | geo_sort_point | geo point for which sorting will be based on | String/Geo Point | optional, is required for bounding box queries if any sort parameters are set. geo distance queries default to use geo_point as the sorting point if this value is not set |
 | geo_sort_order | the order used for sorting geo queries, can either be 'asc' or 'desc' | String | optional, defaults to 'asc' |
 | geo_sort_unit | the unit of measurement for sorting, may be set to 'mi', 'km', 'm','yd', 'ft | String | optional, defaults to 'm' |
+| caCertificate | CA certificate used to validate an https endpoint | String | optional |
 
 `NOTE`: a difference in behavior compared to the elasticsearch_reader is that the default geo distance sort will be ignored if any sort parameter is specified on the query. Sorting on geo distance while specifying another sorting parameter is still possible if you set any other geo sorting parameter, which will cause the query to sort by both.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Elasticsearch Assets",
-    "version": "3.7.1",
+    "version": "3.7.2",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",
@@ -44,7 +44,7 @@
     "devDependencies": {
         "@terascope/data-types": "^0.50.1",
         "@terascope/elasticsearch-api": "^3.20.2",
-        "@terascope/elasticsearch-asset-apis": "^0.12.0",
+        "@terascope/elasticsearch-asset-apis": "^0.12.1",
         "@terascope/eslint-config": "^0.8.0",
         "@terascope/job-components": "^0.75.1",
         "@terascope/scripts": "0.77.2",

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-asset-apis",
     "displayName": "Elasticsearch Asset Apis",
-    "version": "0.12.0",
+    "version": "0.12.1",
     "description": "Elasticsearch reader and sender apis",
     "homepage": "https://github.com/terascope/elasticsearch-assets",
     "repository": "git@github.com:terascope/elasticsearch-assets.git",

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/interfaces.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/interfaces.ts
@@ -364,6 +364,7 @@ export interface SpacesAPIConfig extends ESReaderOptions {
     headers?: AnyObject;
     retry?: number;
     variables?: xLuceneVariables
+    caCertificate?: string;
 }
 
 export interface DetermineSliceResults {


### PR DESCRIPTION
This PR makes the following changes:
- Adds `caCertificate` field to `spaces_reader_api` 
- `SpacesReaderClient` passes the CA certificate to `got`, allowing the connection to an `https` spaces endpoint. 

ref: #1197, #1162