### PR TITLE
Update workflow hash

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-asset-build:
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@f5e098fa861fe7744fa61842e82124f806364be9
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@2a097b4af7eb81cebc7d602ad9ab2f1ef7b979cc
     secrets: inherit

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@f5e098fa861fe7744fa61842e82124f806364be9
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@2a097b4af7eb81cebc7d602ad9ab2f1ef7b979cc
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   check-docker-limit-before:
-   uses: terascope/workflows/.github/workflows/check-docker-limit.yml@f5e098fa861fe7744fa61842e82124f806364be9
+   uses: terascope/workflows/.github/workflows/check-docker-limit.yml@2a097b4af7eb81cebc7d602ad9ab2f1ef7b979cc
    secrets: inherit
 
   cache-docker-images:
     needs: check-docker-limit-before
-    uses: terascope/workflows/.github/workflows/cache-docker-images.yml@f5e098fa861fe7744fa61842e82124f806364be9
+    uses: terascope/workflows/.github/workflows/cache-docker-images.yml@2a097b4af7eb81cebc7d602ad9ab2f1ef7b979cc
     secrets: inherit
 
   test-elasticsearch-assets:
@@ -73,7 +73,7 @@ jobs:
 
   check-docker-limit-after:
     needs: test-elasticsearch-assets
-    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@f5e098fa861fe7744fa61842e82124f806364be9
+    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@2a097b4af7eb81cebc7d602ad9ab2f1ef7b979cc
     secrets: inherit
 
 # TODO:

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,4 +1,4 @@
 {
     "name": "elasticsearch",
-    "version": "4.0.1"
+    "version": "4.0.2"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "asset",
     "displayName": "Asset",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "private": true,
     "description": "",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Elasticsearch Assets",
-    "version": "4.0.1",
+    "version": "4.0.2",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",


### PR DESCRIPTION
This PR updates the github workflows hash to incorporate a fix for the upload-artifact@v4 action during `build-and-publish-asset.yml` workflow