### PR TITLE
Fix publish script to correctly publish to npm

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -9,7 +9,7 @@ check_deps() {
 
 publish() {
     local dryRun="$1"
-    local name tag targetVersion currentVersion isPrivate
+    local name targetVersion currentVersion isPrivate
 
     name="$(jq -r '.name' package.json)"
     isPrivate="$(jq -r '.private' package.json)"
@@ -27,7 +27,7 @@ publish() {
 
         if [ "$dryRun" == "false" ]; then
             yarn npm publish \
-                --tag "$tag"
+                --tag "$targetVersion"
         fi
     else
         echo "Not publishing:"


### PR DESCRIPTION
This PR makes the following changes:

- Fixes publish script issue where the workflow would falsely pass even though it did not publish to npm
- https://github.com/terascope/elasticsearch-assets/actions/runs/12812403151/job/35724009257#step:5:79