### PR TITLE
[CI] update test workflow to upload asset artifacts

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -11,5 +11,5 @@ on:
 jobs:
   call-asset-build:
     if: github.event.pull_request.merged == true
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@2f96a27a56e68c64c67b03d000672f41379e368e
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@5307c8fb58de8d120cc025907cd417407f6c17cb
     secrets: inherit

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@f86f716e47d989b939d978befa7721c1f5b10134
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@5307c8fb58de8d120cc025907cd417407f6c17cb
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -9,13 +9,40 @@ on:
 
 jobs:
   check-docker-limit-before:
-   uses: terascope/workflows/.github/workflows/check-docker-limit.yml@f86f716e47d989b939d978befa7721c1f5b10134
+   uses: terascope/workflows/.github/workflows/check-docker-limit.yml@5307c8fb58de8d120cc025907cd417407f6c17cb
    secrets: inherit
 
   cache-docker-images:
     needs: check-docker-limit-before
-    uses: terascope/workflows/.github/workflows/cache-docker-images.yml@f86f716e47d989b939d978befa7721c1f5b10134
+    uses: terascope/workflows/.github/workflows/cache-docker-images.yml@5307c8fb58de8d120cc025907cd417407f6c17cb
     secrets: inherit
+
+  build-elasticsearch-assets:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
+        node-version: [18, 20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+
+      - run: yarn && yarn setup
+
+      - run: yarn dlx teraslice-cli -v
+      - run: yarn dlx teraslice-cli assets build
+      - run: ls -l build/
+      - name: Archive test build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: teraslice-test-asset-${{ matrix.node-version }}
+          path: ./build
+          retention-days: 7
 
   test-elasticsearch-assets:
     runs-on: ubuntu-latest
@@ -72,7 +99,7 @@ jobs:
 
   check-docker-limit-after:
     needs: test-elasticsearch-assets
-    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@f86f716e47d989b939d978befa7721c1f5b10134
+    uses: terascope/workflows/.github/workflows/check-docker-limit.yml@5307c8fb58de8d120cc025907cd417407f6c17cb
     secrets: inherit
 
 # TODO:

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -93,9 +93,6 @@ jobs:
       - name: Test apis for ${{ matrix.search-version }}
         run: yarn test:${{ matrix.search-version }}
         working-directory: ./packages/elasticsearch-asset-apis
-      - run: yarn dlx teraslice-cli -v
-      - run: yarn dlx teraslice-cli assets build
-      - run: ls -l build/
 
   check-docker-limit-after:
     needs: test-elasticsearch-assets


### PR DESCRIPTION
This PR makes the following changes:
- Update test workflow to upload asset artifacts.
- Use the new terascope/workflows workflow hash
