### PR TITLE
[CI] use correct commit sha for all workflow event triggers

### DIFF
--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -106,6 +106,31 @@ jobs:
         run: yarn test:${{ matrix.search-version }}
         working-directory: ./packages/elasticsearch-asset-apis
 
+  comment-artifact-urls:
+    needs: test-elasticsearch-assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Artifacts List
+        id: artifacts-list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARTIFACTS_JSON=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts)
+          echo $ARTIFACTS_JSON
+          URL_LIST=$(echo "$ARTIFACTS_JSON" | jq -c  '[.artifacts[] | {name: .name, url:.archive_download_url}]')
+          echo $URL_LIST
+          echo "artifact-urls=$URL_LIST" >> "$GITHUB_OUTPUT"
+          
+      - name: Comment on PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          ARTIFACT_URLS='${{ steps.artifacts-list.outputs.artifact-urls }}'
+          LIST=$(echo "$ARTIFACT_URLS" | jq -r '.[] | "\(.name): \(.url)"')
+          COMMENT=$(printf "Asset artifacts:\n%s" "$LIST")
+          gh api repos/${{ github.repository }}/issues/${PR_NUMBER}/comments -f body="$COMMENT"
+
   check-docker-limit-after:
     needs: test-elasticsearch-assets
     uses: terascope/workflows/.github/workflows/check-docker-limit.yml@main

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Commit Short SHA
         id: get-short-sha
         run: |
-          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
+          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.sha }})
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
 
       - name: Append dev tag to version

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Commit Short SHA
         id: get-short-sha
         run: |
-          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          calculatedSha=$(git rev-parse --short ${{ github.event.pull_request.head.sha }})
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
 
       - name: Append dev tag to version


### PR DESCRIPTION
This PR makes the following changes:
- update the `test-asset.yml` workflow to use the latest commit from the branch no matter how the workflow was triggered.
- comment on PR with the artifact urls if all tests pass