### PR TITLE
[CI] skip artifact comment on dependabot PRs

### DIFF
--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -107,8 +107,8 @@ jobs:
         working-directory: ./packages/elasticsearch-asset-apis
 
   comment-artifact-urls:
-    # skip comment on push event (merge to master)
-    if: github.event_name != 'push'
+    # skip comment on push event (merge to master) and dependabot PRs
+    if: github.event_name != 'push' && github.actor != 'dependabot[bot]'
     needs: test-elasticsearch-assets
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Dependabot PRs fail because the `test-asset.yml` workflow makes a comment to the PR. The dependabot actor does not have sufficient permissions to make a PR comment. Granting those permissions would allow the dependabot actor to merge PRs, so we will skip making the comment instead.