### PR TITLE
Add node 24 and remove 18

### DIFF
--- a/.github/workflows/build-and-publish-asset.yml
+++ b/.github/workflows/build-and-publish-asset.yml
@@ -11,5 +11,5 @@ on:
 jobs:
   call-asset-build:
     if: github.event.pull_request.merged == true
-    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@main
+    uses: terascope/workflows/.github/workflows/asset-build-and-publish.yml@f264abdd51e72bf572199763ed5c1de93334e99a
     secrets: inherit

--- a/.github/workflows/daily-docker-cache.yml
+++ b/.github/workflows/daily-docker-cache.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   call-refresh-docker-cache-workflow:
-    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@main
+    uses: terascope/workflows/.github/workflows/refresh-docker-cache.yml@f264abdd51e72bf572199763ed5c1de93334e99a
     secrets: inherit

--- a/.github/workflows/test-asset.yml
+++ b/.github/workflows/test-asset.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [18, 20, 22]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
 
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         # NOTE: Hard Coded Node Version array, should match array in build-and-publish-asset.yml
-        node-version: [18, 20, 22]
+        node-version: [22, 24]
         search-version: [elasticsearch6, elasticsearch7, opensearch1, opensearch2]
     steps:
       - uses: actions/checkout@v4
@@ -122,7 +122,7 @@ jobs:
           ID_LIST=$(echo "$ARTIFACTS_JSON" | jq -c  '[.artifacts[] | {name: .name, id:.id}]')
           echo $ID_LIST
           echo "artifact-ids=$ID_LIST" >> "$GITHUB_OUTPUT"
-          
+
       - name: Comment on PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "elasticsearch",
-    "version": "4.2.4",
+    "version": "4.3.0",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "asset",
     "displayName": "Asset",
-    "version": "4.2.4",
+    "version": "4.3.0",
     "private": true,
     "description": "",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "eslint": "~9.27.0",
         "fs-extra": "~11.3.0",
         "jest": "~29.7.0",
-        "jest-extended": "~4.0.2",
+        "jest-extended": "~5.0.3",
         "moment": "~2.30.1",
         "nock": "~14.0.4",
         "node-notifier": "~10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Elasticsearch Assets",
-    "version": "4.2.4",
+    "version": "4.3.0",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3668,7 +3668,7 @@ __metadata:
     eslint: "npm:~9.27.0"
     fs-extra: "npm:~11.3.0"
     jest: "npm:~29.7.0"
-    jest-extended: "npm:~4.0.2"
+    jest-extended: "npm:~5.0.3"
     moment: "npm:~2.30.1"
     nock: "npm:~14.0.4"
     node-notifier: "npm:~10.0.1"
@@ -5979,22 +5979,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-extended@npm:~4.0.2":
-  version: 4.0.2
-  resolution: "jest-extended@npm:4.0.2"
+"jest-extended@npm:~5.0.3":
+  version: 5.0.3
+  resolution: "jest-extended@npm:5.0.3"
   dependencies:
     jest-diff: "npm:^29.0.0"
-    jest-get-type: "npm:^29.0.0"
   peerDependencies:
     jest: ">=27.2.5"
   peerDependenciesMeta:
     jest:
       optional: true
-  checksum: 10c0/305fdb6885ab71755830b70690b8db6ea6fd9adca92360ea1a37c0d2fa6567a68b57178dd7707d112fc57b01ab75b66f28a1c550ed0e6b1b8628600a812c2277
+  checksum: 10c0/37b80f90be141e2bb3344346962e435e6b8c5a121d5c6ad89865b07ff9f0810c2f273eb7ea4c00d3fc71a07667fee4da100c2190f180ae3662d023c19e24146a
   languageName: node
   linkType: hard
 
-"jest-get-type@npm:^29.0.0, jest-get-type@npm:^29.6.3":
+"jest-get-type@npm:^29.6.3":
   version: 29.6.3
   resolution: "jest-get-type@npm:29.6.3"
   checksum: 10c0/552e7a97a983d3c2d4e412a44eb7de0430ff773dd99f7500962c268d6dfbfa431d7d08f919c9d960530e5f7f78eb47f267ad9b318265e5092b3ff9ede0db7c2b
@@ -9392,9 +9391,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.21.1":
-  version: 6.21.1
-  resolution: "undici@npm:6.21.1"
-  checksum: 10c0/d604080e4f8db89b35a63b483b5f96a5f8b19ec9f716e934639345449405809d2997e1dd7212d67048f210e54534143384d712bd9075e4394f0788895ef9ca8e
+  version: 6.21.3
+  resolution: "undici@npm:6.21.3"
+  checksum: 10c0/294da109853fad7a6ef5a172ad0ca3fb3f1f60cf34703d062a5ec967daf69ad8c03b52e6d536c5cba3bb65615769bf08e5b30798915cbccdddaca01045173dda
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR makes the following changes:

- Bumps file-assets from `v3.0.7` to `v3.1.0`
- A change to workflows will discontinue testing for node 18/20 and add testing for node 24
  - Elasticsearch-assets runs tests separately from the workflows repo. The workflow still applies to building and publishing the asset
    - https://github.com/terascope/workflows/pull/37
- Bumps `jest-extended` from `v4.0.2` to `v5.0.3`
- Bumps `undici ` from `v6.21.1` to `v6.21.3`