### PR TITLE
bundled deps update 2025-06-23

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "elasticsearch",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "minimum_teraslice_version": "2.0.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Asset",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "private": true,
     "description": "Teraslice asset for elasticsearch operations",
     "license": "MIT",
@@ -20,7 +20,7 @@
     "dependencies": {
         "@terascope/data-mate": "~1.8.4",
         "@terascope/elasticsearch-api": "~4.9.3",
-        "@terascope/elasticsearch-asset-apis": "~1.2.4",
+        "@terascope/elasticsearch-asset-apis": "~1.2.5",
         "@terascope/job-components": "~1.10.3",
         "@terascope/teraslice-state-storage": "~1.9.3",
         "@terascope/utils": "~1.8.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-asset-bundle",
     "displayName": "Elasticsearch Asset Bundle",
-    "version": "4.3.1",
+    "version": "4.3.2",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",
@@ -47,7 +47,7 @@
     "devDependencies": {
         "@terascope/data-types": "~1.8.4",
         "@terascope/elasticsearch-api": "~4.9.3",
-        "@terascope/elasticsearch-asset-apis": "~1.2.4",
+        "@terascope/elasticsearch-asset-apis": "~1.2.5",
         "@terascope/eslint-config": "~1.1.18",
         "@terascope/job-components": "~1.10.3",
         "@terascope/scripts": "~1.18.1",

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-asset-apis",
     "displayName": "Elasticsearch Asset Apis",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "description": "Elasticsearch reader and sender apis",
     "homepage": "https://github.com/terascope/elasticsearch-assets",
     "repository": "git@github.com:terascope/elasticsearch-assets.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,7 +1585,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@terascope/elasticsearch-asset-apis@npm:~1.2.4, @terascope/elasticsearch-asset-apis@workspace:packages/elasticsearch-asset-apis":
+"@terascope/elasticsearch-asset-apis@npm:~1.2.5, @terascope/elasticsearch-asset-apis@workspace:packages/elasticsearch-asset-apis":
   version: 0.0.0-use.local
   resolution: "@terascope/elasticsearch-asset-apis@workspace:packages/elasticsearch-asset-apis"
   dependencies:
@@ -4132,7 +4132,7 @@ __metadata:
   dependencies:
     "@terascope/data-types": "npm:~1.8.4"
     "@terascope/elasticsearch-api": "npm:~4.9.3"
-    "@terascope/elasticsearch-asset-apis": "npm:~1.2.4"
+    "@terascope/elasticsearch-asset-apis": "npm:~1.2.5"
     "@terascope/eslint-config": "npm:~1.1.18"
     "@terascope/job-components": "npm:~1.10.3"
     "@terascope/scripts": "npm:~1.18.1"
@@ -4165,7 +4165,7 @@ __metadata:
   dependencies:
     "@terascope/data-mate": "npm:~1.8.4"
     "@terascope/elasticsearch-api": "npm:~4.9.3"
-    "@terascope/elasticsearch-asset-apis": "npm:~1.2.4"
+    "@terascope/elasticsearch-asset-apis": "npm:~1.2.5"
     "@terascope/job-components": "npm:~1.10.3"
     "@terascope/teraslice-state-storage": "npm:~1.9.3"
     "@terascope/utils": "npm:~1.8.3"


### PR DESCRIPTION
This PR updates the following dependencies:

- Bumps **Elasticsearch-Assets** from `v4.3.1` to `v4.3.2`
- Bumps **@terascope/elasticsearch-asset-apis** from `v1.2.4` to `v1.2.5`

## Elasticsearch-Asset
- @terascope/data-mate: `v1.8.4`
- @terascope/elasticsearch-api: `v4.9.3`
- @terascope/job-components: `v1.10.3`
- @terascope/teraslice-state-storage: `v1.9.3`
- @terascope/utils: `v1.8.3`

## Workspace
- @terascope/data-types: `v1.8.4`
- @terascope/elasticsearch-api: `v4.9.3`
- @terascope/eslint-config: `v1.1.18`
- @terascope/job-components: `v1.10.3`
- @terascope/scripts: `v1.18.1`
- @terascope/teraslice-state-storage: `v1.9.3`
- elasticsearch-store: `v1.10.6`
- jest: `v30.0.2`

## @terascope/elasticsearch-asset-apis
- @terascope/data-mate: `v1.8.4`
- @terascope/data-types: `v1.8.4`
- @terascope/elasticsearch-api: `v4.9.3`
- @terascope/utils: `v1.8.3`
- @terascope/scripts: `v1.18.1`
- jest: `v30.0.2`