### PR TITLE
Fix too_many_clauses errors not being exposed to users

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm test:*)",
+      "Bash(yarn test:*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,8 @@
   "permissions": {
     "allow": [
       "Bash(npm test:*)",
-      "Bash(yarn test:*)"
+      "Bash(yarn test:*)",
+      "Bash(yarn lint)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# Elasticsearch Assets - Claude Knowledge
+
+## Quick Reference
+
+### Development Commands
+
+```bash
+yarn install          # Install dependencies
+yarn build            # Build TypeScript
+yarn build:watch      # Build with file watching
+```
+
+### Testing
+
+```bash
+yarn test             # Run tests (requires Docker for Elasticsearch)
+yarn test:watch       # Run tests in watch mode
+yarn test:debug       # Run tests with debugging
+```
+
+**Note**: Tests require Docker to spin up Elasticsearch/OpenSearch instances.
+
+### Linting
+
+```bash
+yarn lint             # Check code style with ESLint
+yarn lint:fix         # Auto-fix linting issues
+```
+
+Uses `@terascope/eslint-config` with stylistic rules for spacing and line breaks.
+
+## Project Structure
+
+### Key Directories
+
+- `asset/src/` - Main asset operations (spaces_reader, elasticsearch_reader, etc.)
+- `packages/elasticsearch-asset-apis/` - Core API implementations
+- `test/` - Test files mirroring src structure
+
+### Main Components
+
+- **Readers**: `spaces_reader`, `elasticsearch_reader`, `id_reader`
+- **Base Classes**: `ReaderAPIFetcher`, `DateReaderAPISlicer`, `ElasticsearchReaderAPI`
+- **Clients**: `SpacesReaderClient`, `ElasticsearchReaderClient`
+
+## Error Handling Architecture
+
+Reader operations flow: `Slicer.initialize()` → `ElasticsearchReaderAPI.makeDateSlicerRanges()` → `client.count()` → potential errors
+
+Errors during slicer initialization can cause jobs to silently "complete" instead of failing properly.

--- a/asset/src/__lib/DateReaderAPISlicer.ts
+++ b/asset/src/__lib/DateReaderAPISlicer.ts
@@ -24,18 +24,25 @@ export class DateReaderAPISlicer extends ParallelSlicer<SharedReaderConfig> {
         const { lifecycle, slicers } = this.executionConfig;
         const { startTime } = this;
 
-        this.slicerRanges = await this.api.makeDateSlicerRanges({
-            lifecycle,
-            numOfSlicers: slicers,
-            recoveryData,
-            startTime,
-            hook: async (params) => {
-                if (!this.hasUpdated) {
-                    await this.updateJob(params);
-                    this.hasUpdated = true;
-                }
-            },
-        });
+        try {
+            this.slicerRanges = await this.api.makeDateSlicerRanges({
+                lifecycle,
+                numOfSlicers: slicers,
+                recoveryData,
+                startTime,
+                hook: async (params) => {
+                    if (!this.hasUpdated) {
+                        await this.updateJob(params);
+                        this.hasUpdated = true;
+                    }
+                },
+            });
+        } catch (error) {
+            // Re-throw elasticsearch errors with more context to prevent them
+            // from being treated as "no data found" scenarios
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            throw new Error(`Failed to initialize date slicer ranges: ${errorMessage}`);
+        }
 
         await super.initialize(recoveryData);
     }

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/throwRequestError.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/throwRequestError.ts
@@ -29,25 +29,25 @@ export function throwRequestError(endpointName: string, statusCode: number, body
             });
         } else {
             let errorMessage = resp.error;
-            
+
             // Check if this is an elasticsearch error that should be surfaced to the user
             if (typeof resp.error === 'string') {
-                if (resp.error.includes('search_phase_execution_exception') || 
-                    resp.error.includes('too_many_clauses') ||
-                    resp.error.includes('maxClauseCount')) {
+                if (resp.error.includes('search_phase_execution_exception')
+                    || resp.error.includes('too_many_clauses')
+                    || resp.error.includes('maxClauseCount')) {
                     errorMessage = `Elasticsearch query failed: ${resp.error}`;
                 }
             }
-            
+
             // Check if the error is in a nested structure common in elasticsearch responses
             if (resp.error && typeof resp.error === 'object') {
                 const nestedError = resp.error;
-                if (nestedError.type === 'search_phase_execution_exception' || 
-                    (nestedError.reason && nestedError.reason.includes('too_many_clauses'))) {
+                if (nestedError.type === 'search_phase_execution_exception'
+                    || (nestedError.reason && nestedError.reason.includes('too_many_clauses'))) {
                     errorMessage = `Elasticsearch query failed: ${nestedError.reason || nestedError.type}`;
                 }
             }
-            
+
             throw new TSError(errorMessage, {
                 statusCode,
                 context: {

--- a/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/throwRequestError.ts
+++ b/packages/elasticsearch-asset-apis/src/elasticsearch-reader-api/throwRequestError.ts
@@ -28,11 +28,31 @@ export function throwRequestError(endpointName: string, statusCode: number, body
                 }
             });
         } else {
-            throw new TSError(resp.error, {
+            let errorMessage = resp.error;
+            
+            // Check if this is an elasticsearch error that should be surfaced to the user
+            if (typeof resp.error === 'string') {
+                if (resp.error.includes('search_phase_execution_exception') || 
+                    resp.error.includes('too_many_clauses') ||
+                    resp.error.includes('maxClauseCount')) {
+                    errorMessage = `Elasticsearch query failed: ${resp.error}`;
+                }
+            }
+            
+            // Check if the error is in a nested structure common in elasticsearch responses
+            if (resp.error && typeof resp.error === 'object') {
+                const nestedError = resp.error;
+                if (nestedError.type === 'search_phase_execution_exception' || 
+                    (nestedError.reason && nestedError.reason.includes('too_many_clauses'))) {
+                    errorMessage = `Elasticsearch query failed: ${nestedError.reason || nestedError.type}`;
+                }
+            }
+            
+            throw new TSError(errorMessage, {
                 statusCode,
                 context: {
                     endpoint: endpointName,
-                    safe: true
+                    safe: typeof errorMessage === 'string' && errorMessage.startsWith('Elasticsearch query failed') ? false : true
                 }
             });
         }

--- a/test/spaces_reader/slicer-spec.ts
+++ b/test/spaces_reader/slicer-spec.ts
@@ -263,7 +263,8 @@ describe('spaces_reader slicer', () => {
                     }
                 });
 
-            // Mock the elasticsearch error response for too many clauses during slicer initialization
+            // Mock the elasticsearch error response for too many clauses during
+            // slicer initialization
             // The slicer calls getIndexDate twice - once for start (asc) and once for end (desc)
             scope.post(`/${testIndex}?token=${token}`, {
                 q: 'ip:(TERM_1 OR TERM_2 OR TERM_3)',


### PR DESCRIPTION
When Elasticsearch queries exceed the maxClauseCount limit (1024 by default), they fail with a search_phase_execution_exception containing too_many_clauses. Previously, these errors were not properly surfaced to users, causing jobs to appear "completed" instead of failed.

**Root Cause:**
- Errors during slicer initialization (count operations) were being caught and treated as "no data found" scenarios
- SpacesReaderClient error handling didn't properly format elasticsearch errors
- Job lifecycle treated failed slice range creation as successful completion

**Changes:**
1. Enhanced throwRequestError() to detect and properly format elasticsearch search_phase_execution_exception errors including too_many_clauses
2. Added error handling wrapper in DateReaderAPISlicer.initialize() to prevent elasticsearch errors from being silently treated as "no data"
3. Added comprehensive tests for both fetcher and slicer error scenarios

**Impact:**
- Users now receive clear error messages when queries have too many clauses
- Jobs fail properly instead of appearing to complete successfully
- Error messages include specific elasticsearch error details

Fixes #1512

🤖 Generated with [Claude Code](https://claude.ai/code)