### PR TITLE
move isolatedModules config to tsconfig

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,7 +35,6 @@ export default {
     transform: {
         '\\.[jt]sx?$': ['ts-jest',
             {
-                isolatedModules: true,
                 tsconfig: './tsconfig.json',
                 diagnostics: true,
                 pretty: true,

--- a/packages/elasticsearch-asset-apis/jest.config.js
+++ b/packages/elasticsearch-asset-apis/jest.config.js
@@ -16,7 +16,6 @@ export default {
     transform: {
         '\\.[jt]sx?$': ['ts-jest',
             {
-                isolatedModules: true,
                 tsconfig: './tsconfig.json',
                 diagnostics: true,
                 pretty: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "module": "ESNext",
         "skipLibCheck": true,
         "experimentalDecorators": true,
+        "isolatedModules": true,
         "strict": true,
         "noFallthroughCasesInSwitch": true,
         "preserveConstEnums": true,


### PR DESCRIPTION
This PR makes the following changes:

- moves `isolatedModules` config from jest config to tsconfig
  - Fixes a warn by jest that recommends this change 