### PR TITLE
Bump minimum_teraslice_version to 3.15.0

### DIFF
--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "elasticsearch",
     "version": "5.1.8",
-    "minimum_teraslice_version": "3.3.0"
+    "minimum_teraslice_version": "3.15.0"
 }

--- a/asset/asset.json
+++ b/asset/asset.json
@@ -1,5 +1,5 @@
 {
     "name": "elasticsearch",
-    "version": "5.1.8",
+    "version": "5.2.0",
     "minimum_teraslice_version": "3.15.0"
 }

--- a/asset/package.json
+++ b/asset/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-assets",
     "displayName": "Asset",
-    "version": "5.1.8",
+    "version": "5.2.0",
     "private": true,
     "description": "Teraslice asset for elasticsearch operations",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "elasticsearch-asset-bundle",
     "displayName": "Elasticsearch Asset Bundle",
-    "version": "5.1.8",
+    "version": "5.2.0",
     "private": true,
     "description": "bundle of processors for teraslice",
     "homepage": "https://github.com/terascope/elasticsearch-assets#readme",

--- a/packages/elasticsearch-asset-apis/package.json
+++ b/packages/elasticsearch-asset-apis/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@terascope/elasticsearch-asset-apis",
     "displayName": "Elasticsearch Asset Apis",
-    "version": "2.1.8",
+    "version": "2.1.9",
     "description": "Elasticsearch reader and sender apis",
     "homepage": "https://github.com/terascope/elasticsearch-assets",
     "repository": "git@github.com:terascope/elasticsearch-assets.git",


### PR DESCRIPTION
This PR makes the following changes:

- Bumps `minimum_teraslice_version` from `v3.3.0` to `v3.15.0`
- Bumps Elasticsearch Assets from `v5.1.8` to `v5.2.0`

ref to issue https://github.com/terascope/teraslice/issues/4509